### PR TITLE
Add repeatable source and production verification gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,144 @@
+name: AORI ROOM quality gates
+
+on:
+  pull_request:
+    branches: [source-direct-v1.2]
+  push:
+    branches: [source-direct-v1.2]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aori-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Unit, build, and local network smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.15
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run unit tests
+        run: bun run test
+
+      - name: Type-check and build
+        env:
+          AORI_BUILD_SHA: ${{ github.sha }}
+        run: bun run build:app
+
+      - name: Start local Worker
+        shell: bash
+        run: |
+          set -euo pipefail
+          bunx wrangler dev --local --port 8787 > "$RUNNER_TEMP/wrangler.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/wrangler.pid"
+
+      - name: Wait for local Worker
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..60}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8787/ > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/wrangler.log"
+          exit 1
+
+      - name: Exercise room and WebSocket protocol
+        env:
+          BASE_URL: http://127.0.0.1:8787
+          EXPECTED_SHA: ${{ github.sha }}
+          WAIT_FOR_RELEASE_MS: 0
+        run: bun run smoke:network
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-verification-${{ github.run_id }}
+          path: |
+            dist/
+            ${{ runner.temp }}/wrangler.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  production-smoke:
+    name: Verify deployed commit
+    needs: verify
+    if: github.event_name == 'push' && vars.PRODUCTION_BASE_URL != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Wait for this commit and exercise production
+        env:
+          BASE_URL: ${{ vars.PRODUCTION_BASE_URL }}
+          EXPECTED_SHA: ${{ github.sha }}
+          WAIT_FOR_RELEASE_MS: 900000
+          RELEASE_POLL_MS: 5000
+        run: node scripts/network-smoke.mjs
+
+      - name: Capture iPhone-sized production screenshot
+        shell: bash
+        env:
+          BASE_URL: ${{ vars.PRODUCTION_BASE_URL }}
+        run: |
+          set -euo pipefail
+          mkdir -p production-artifacts
+          npx --yes playwright@latest install --with-deps webkit
+          npx --yes playwright@latest screenshot \
+            --browser=webkit \
+            --device="iPhone 13" \
+            --wait-for-selector=".title-screen--v2" \
+            --wait-for-timeout=2500 \
+            "$BASE_URL" \
+            production-artifacts/title-iphone.png
+
+      - name: Upload production evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-evidence-${{ github.sha }}
+          path: production-artifacts/
+          if-no-files-found: warn
+          retention-days: 30
+
+  production-configuration-required:
+    name: Production URL configuration
+    needs: verify
+    if: github.event_name == 'push' && vars.PRODUCTION_BASE_URL == ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail until the production URL is configured
+        shell: bash
+        run: |
+          echo "PRODUCTION_BASE_URL is not configured. Add it under Settings → Secrets and variables → Actions → Variables." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 .dev.vars
 
 *.tsbuildinfo
+public/release.json
+production-artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@ dist/
 *.log
 .playwright-*.mjs
 .network-check.mjs
-.wrangler/
 .dev.vars
-
 *.tsbuildinfo
 public/release.json
+playwright-report/
+test-results/
 production-artifacts/

--- a/docs/PRODUCTION_VERIFICATION.md
+++ b/docs/PRODUCTION_VERIFICATION.md
@@ -1,0 +1,57 @@
+# 本番検証の運用
+
+AORI ROOMでは、**「ビルドが通った」ことと「本番で動く」ことを別々に判定**します。検証は3段階です。
+
+## Gate 1 — ソース検証
+
+`source-direct-v1.2`向けのPull Requestごとに、次を自動実行します。
+
+1. ロックファイルどおりの依存関係インストール
+2. Vitestユニットテスト
+3. TypeScript型検査とVite本番ビルド
+4. Durable Objectを含むCloudflare Workerのローカル起動
+5. HTTPとWebSocketを使った2クライアント実通信試験
+
+実通信試験では、静的配信、部屋作成・参加、2人上限、presence、双方向の座標・モーション中継、ルミ／ミオ／セナのキャラクター同期、不正キャラクターIDの除去、吹き出しのサニタイズ、ping/pong、ゲスト再接続と`peerState`復元まで確認します。
+
+## Gate 2 — デプロイ済みリビジョン検証
+
+本番ビルド時に`public/release.json`を生成します。ここへアプリのバージョン、プロトコル番号、キャラクター一覧、ビルド元のGitコミットSHAを記録します。
+
+`source-direct-v1.2`へのpush後、本番検証ジョブは公開中の`release.json`が**そのpushと同じSHA**になるまで待機します。一致後に、本番URLへGate 1と同じルーム／WebSocket試験を実行します。これにより、古いデプロイ先を検査して誤って成功扱いすることを防ぎます。
+
+さらにWebKitをiPhone 13相当で起動し、`.title-screen--v2`が実際に描画されるまで待ってタイトル画面を撮影します。画像はGitHub Actionsの成果物として30日保存します。
+
+## Gate 3 — 定期本番監視
+
+`main`上の監視ワークフローを6時間ごとに実行します。`source-direct-v1.2`の最新SHAと本番`release.json`を比較したうえで、API、WebSocket、キャラクター同期、再接続を再試験します。手動実行時は一時的なURL指定も可能です。
+
+## 一度だけ必要な設定
+
+GitHub ActionsのRepository Variableを作成します。
+
+- 名前: `PRODUCTION_BASE_URL`
+- 値: 本番のHTTPS URL。末尾のパスは付けない
+
+場所: **Settings → Secrets and variables → Actions → Variables**
+
+Cloudflareの本番ブランチは`source-direct-v1.2`にします。Pull Requestをマージする前には`Unit, build, and local network smoke`を必須チェックにし、リリース完了の判定は`Verify deployed commit`の成功まで待ちます。URLが未設定の場合は検証をスキップせず、明示的に失敗させます。
+
+## 手動実行
+
+ローカルWorker:
+
+```bash
+BASE_URL=http://127.0.0.1:8787 node scripts/network-smoke.mjs
+```
+
+本番と特定リビジョンの照合:
+
+```bash
+BASE_URL=https://example.com \
+EXPECTED_SHA=$(git rev-parse HEAD) \
+WAIT_FOR_RELEASE_MS=900000 \
+node scripts/network-smoke.mjs
+```
+
+いずれかのassertionに失敗すると終了コードが非0になり、一時作成したWebSocketは成功・失敗にかかわらず閉じます。

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "deploy": "bunx wrangler deploy",
     "preview": "vite preview --host 0.0.0.0",
     "smoke:network": "node scripts/network-smoke.mjs",
-    "check": "npm run test && npm run build",
-    "build:app": "tsc -b --pretty false && vite build"
+    "smoke:production": "node scripts/network-smoke.mjs",
+    "check": "npm run test && npm run build:app",
+    "build:app": "node scripts/write-release-meta.mjs && tsc -b --pretty false && vite build"
   },
   "keywords": [],
   "author": "",

--- a/scripts/network-smoke.mjs
+++ b/scripts/network-smoke.mjs
@@ -1,53 +1,423 @@
-import assert from 'node:assert/strict';
+import assert from "node:assert/strict";
 
-const base='http://127.0.0.1:8787';
-const create=await fetch(`${base}/api/rooms`,{method:'POST',headers:{'content-type':'application/json'},body:'{}'});
-assert.equal(create.status,201);
-const host=await create.json();
-assert.match(host.roomCode,/^\d{5}$/);
-const join=await fetch(`${base}/api/rooms/${host.roomCode}/join`,{method:'POST',headers:{'content-type':'application/json'},body:'{}'});
-assert.equal(join.status,200);
-const guest=await join.json();
+const DEFAULT_BASE_URL = "http://127.0.0.1:8787";
+const REQUEST_TIMEOUT_MS = numberFromEnv("REQUEST_TIMEOUT_MS", 10_000);
+const SOCKET_TIMEOUT_MS = numberFromEnv("SOCKET_TIMEOUT_MS", 8_000);
+const WAIT_FOR_RELEASE_MS = numberFromEnv("WAIT_FOR_RELEASE_MS", 0);
+const RELEASE_POLL_MS = numberFromEnv("RELEASE_POLL_MS", 5_000);
+const EXPECTED_SHA = (process.env.EXPECTED_SHA ?? "").trim().toLowerCase();
+const baseUrl = normalizeBaseUrl(process.env.BASE_URL ?? DEFAULT_BASE_URL);
 
-function connect(session){
-  return new Promise((resolve,reject)=>{
-    const ws=new WebSocket(`ws://127.0.0.1:8787/ws/${session.roomCode}?token=${session.token}`);
-    const timer=setTimeout(()=>reject(new Error('socket timeout')),5000);
-    ws.addEventListener('open',()=>{clearTimeout(timer);resolve(ws)},{once:true});
-    ws.addEventListener('error',()=>reject(new Error('socket error')),{once:true});
-  });
+let hostSocket;
+let guestSocket;
+let resumedGuestSocket;
+
+function numberFromEnv(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
 }
-function waitMessage(ws,predicate,label){
-  return new Promise((resolve,reject)=>{
-    const timer=setTimeout(()=>{ws.removeEventListener('message',onMessage);reject(new Error(`message timeout: ${label}`));},5000);
-    const onMessage=(event)=>{
-      const data=JSON.parse(String(event.data));
-      if(!predicate(data)) return;
-      clearTimeout(timer);ws.removeEventListener('message',onMessage);resolve(data);
-    };
-    ws.addEventListener('message',onMessage);
-  });
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`BASE_URL must use http or https: ${value}`);
+  }
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url;
 }
-const hostWelcomeP = (async()=>{const ws=await connect(host); return {ws,welcome:await waitMessage(ws,m=>m.type==='welcome','host welcome')}})();
-const {ws:hostWs,welcome:hostWelcome}=await hostWelcomeP;
-assert.equal(hostWelcome.role,'host');
-const hostSeesGuest = waitMessage(hostWs,m=>m.type==='presence'&&m.presence.guest===true,'host sees guest');
-const guestWs=await connect(guest);
-const guestWelcome=await waitMessage(guestWs,m=>m.type==='welcome','guest welcome');
-assert.equal(guestWelcome.role,'guest');
-const presence=await hostSeesGuest;
-assert.equal(presence.presence.host,true);
 
-const state={x:1.25,z:-0.5,yaw:0.7,speed:4.1,motion:'start-left',motionSequence:9,clientTime:123};
-const stateReceived=waitMessage(guestWs,m=>m.type==='state'&&m.state?.motionSequence===9,'state relay');
-hostWs.send(JSON.stringify({type:'state',state}));
-assert.deepEqual((await stateReceived).state,state);
+function httpUrl(pathname) {
+  return new URL(pathname.replace(/^\//, ""), baseUrl);
+}
 
-const bubbleReceived=waitMessage(hostWs,m=>m.type==='bubble'&&m.text==='ぐるぐる〜','bubble relay');
-guestWs.send(JSON.stringify({type:'bubble',text:'ぐるぐる〜',sequence:7}));
-const bubble=await bubbleReceived;
-assert.equal(bubble.role,'guest');
-assert.equal(bubble.sequence,7);
+function socketUrl(session) {
+  const url = httpUrl(`ws/${session.roomCode}`);
+  url.protocol = baseUrl.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("token", session.token);
+  return url;
+}
 
-hostWs.close(1000,'done'); guestWs.close(1000,'done');
-console.log(JSON.stringify({roomCode:host.roomCode,hostWelcome,guestWelcome,bubble},null,2));
+function withTimeout(promise, timeoutMs, label) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+async function fetchWithTimeout(pathname, init = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(httpUrl(pathname), {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        "cache-control": "no-cache",
+        ...init.headers,
+      },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchJson(pathname, init, expectedStatus) {
+  const response = await fetchWithTimeout(pathname, init);
+  const text = await response.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`${pathname} returned non-JSON (${response.status}): ${text.slice(0, 160)}`);
+  }
+  assert.equal(
+    response.status,
+    expectedStatus,
+    `${pathname} status ${response.status}; response=${JSON.stringify(data)}`,
+  );
+  return data;
+}
+
+function shaMatches(actual, expected) {
+  if (!actual || !expected) return false;
+  const normalizedActual = String(actual).trim().toLowerCase();
+  return normalizedActual.startsWith(expected) || expected.startsWith(normalizedActual);
+}
+
+async function fetchRelease() {
+  const response = await fetchWithTimeout(`release.json?smoke=${Date.now()}`);
+  if (response.status !== 200) return null;
+  return response.json().catch(() => null);
+}
+
+async function waitForExpectedRelease() {
+  if (!EXPECTED_SHA) return null;
+  const deadline = Date.now() + WAIT_FOR_RELEASE_MS;
+  let lastRelease = null;
+  let lastError = null;
+
+  do {
+    try {
+      lastRelease = await fetchRelease();
+      if (lastRelease && shaMatches(lastRelease.gitSha, EXPECTED_SHA)) return lastRelease;
+      lastError = new Error(
+        `release.json gitSha=${JSON.stringify(lastRelease?.gitSha ?? null)}; expected ${EXPECTED_SHA}`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, RELEASE_POLL_MS));
+  } while (true);
+
+  throw lastError ?? new Error(`release ${EXPECTED_SHA} was not observed`);
+}
+
+class SocketProbe {
+  static async connect(session, label) {
+    const socket = new WebSocket(socketUrl(session));
+    const probe = new SocketProbe(socket, label);
+    await probe.opened;
+    return probe;
+  }
+
+  constructor(socket, label) {
+    this.socket = socket;
+    this.label = label;
+    this.queue = [];
+    this.waiters = new Set();
+    this.closed = false;
+
+    this.opened = withTimeout(
+      new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener(
+          "error",
+          () => reject(new Error(`${label} websocket error before open`)),
+          { once: true },
+        );
+      }),
+      SOCKET_TIMEOUT_MS,
+      `${label} websocket open`,
+    );
+
+    socket.addEventListener("message", (event) => {
+      let message;
+      try {
+        message = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      for (const waiter of this.waiters) {
+        if (!waiter.predicate(message)) continue;
+        this.waiters.delete(waiter);
+        clearTimeout(waiter.timer);
+        waiter.resolve(message);
+        return;
+      }
+      this.queue.push(message);
+    });
+
+    socket.addEventListener("close", (event) => {
+      this.closed = true;
+      for (const waiter of this.waiters) {
+        clearTimeout(waiter.timer);
+        waiter.reject(
+          new Error(`${label} closed before ${waiter.description} (${event.code}: ${event.reason})`),
+        );
+      }
+      this.waiters.clear();
+    });
+  }
+
+  next(predicate, description, timeoutMs = SOCKET_TIMEOUT_MS) {
+    const index = this.queue.findIndex(predicate);
+    if (index >= 0) return Promise.resolve(this.queue.splice(index, 1)[0]);
+    if (this.closed) return Promise.reject(new Error(`${this.label} is already closed`));
+
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        predicate,
+        description,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.waiters.delete(waiter);
+          reject(new Error(`${this.label} message timed out: ${description}`));
+        }, timeoutMs),
+      };
+      this.waiters.add(waiter);
+    });
+  }
+
+  send(value) {
+    assert.equal(this.socket.readyState, WebSocket.OPEN, `${this.label} socket is not open`);
+    this.socket.send(JSON.stringify(value));
+  }
+
+  async close() {
+    if (this.socket.readyState === WebSocket.CLOSED) return;
+    const closed = new Promise((resolve) => {
+      this.socket.addEventListener("close", resolve, { once: true });
+    });
+    this.socket.close(1000, "smoke complete");
+    await withTimeout(closed, 3_000, `${this.label} websocket close`).catch(() => undefined);
+  }
+}
+
+async function verifyStaticApp() {
+  const response = await fetchWithTimeout("/");
+  assert.equal(response.status, 200, `GET / returned ${response.status}`);
+  const contentType = response.headers.get("content-type") ?? "";
+  assert.match(contentType, /text\/html/i, `GET / content-type=${contentType}`);
+  const html = await response.text();
+  assert.match(html, /id=["']app["']/i, "app mount is missing from HTML");
+  assert.match(html, /AORI ROOM/i, "AORI ROOM marker is missing from HTML");
+}
+
+function verifyReleaseMetadata(release) {
+  assert.ok(release && typeof release === "object", "release.json is missing or invalid");
+  assert.equal(release.service, "aori-room");
+  assert.equal(release.protocolVersion, 2);
+  assert.match(String(release.version ?? ""), /^\d+\.\d+\.\d+/);
+  assert.ok(typeof release.gitSha === "string" && release.gitSha.length >= 7);
+  assert.deepEqual(release.characters, ["lumi", "mio", "sena"]);
+}
+
+async function run() {
+  const startedAt = Date.now();
+  const release = EXPECTED_SHA ? await waitForExpectedRelease() : await fetchRelease();
+  verifyReleaseMetadata(release);
+  await verifyStaticApp();
+
+  const host = await fetchJson(
+    "/api/rooms",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    },
+    201,
+  );
+  assert.match(host.roomCode, /^\d{5}$/);
+  assert.equal(host.role, "host");
+  assert.match(host.token, /^[0-9a-f]{48}$/i);
+
+  const guest = await fetchJson(
+    `/api/rooms/${host.roomCode}/join`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    },
+    200,
+  );
+  assert.equal(guest.roomCode, host.roomCode);
+  assert.equal(guest.role, "guest");
+  assert.match(guest.token, /^[0-9a-f]{48}$/i);
+
+  hostSocket = await SocketProbe.connect(host, "host");
+  const hostWelcome = await hostSocket.next((message) => message.type === "welcome", "host welcome");
+  assert.equal(hostWelcome.role, "host");
+  assert.equal(hostWelcome.roomCode, host.roomCode);
+
+  const hostSeesGuest = hostSocket.next(
+    (message) => message.type === "presence" && message.presence?.guest === true,
+    "host sees guest",
+  );
+  guestSocket = await SocketProbe.connect(guest, "guest");
+  const guestWelcome = await guestSocket.next(
+    (message) => message.type === "welcome",
+    "guest welcome",
+  );
+  assert.equal(guestWelcome.role, "guest");
+  assert.equal(guestWelcome.presence?.host, true);
+  await hostSeesGuest;
+
+  const thirdJoin = await fetchJson(
+    `/api/rooms/${host.roomCode}/join`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    },
+    409,
+  );
+  assert.match(String(thirdJoin.message ?? ""), /2人|すでに/);
+
+  const hostState = {
+    x: 1.25,
+    z: -0.5,
+    yaw: 0.7,
+    speed: 4.1,
+    motion: "start-left",
+    motionSequence: 9,
+    clientTime: 123,
+    characterId: "lumi",
+  };
+  const guestReceivesHost = guestSocket.next(
+    (message) => message.type === "state" && message.state?.motionSequence === 9,
+    "guest receives host state",
+  );
+  hostSocket.send({ type: "state", state: hostState });
+  assert.deepEqual((await guestReceivesHost).state, hostState);
+
+  const guestState = {
+    x: -1.1,
+    z: 0.8,
+    yaw: -0.4,
+    speed: 2.2,
+    motion: "sandori",
+    motionSequence: 12,
+    clientTime: 456,
+    characterId: "sena",
+  };
+  const hostReceivesGuest = hostSocket.next(
+    (message) => message.type === "state" && message.state?.motionSequence === 12,
+    "host receives guest state",
+  );
+  guestSocket.send({ type: "state", state: guestState });
+  assert.deepEqual((await hostReceivesGuest).state, guestState);
+
+  await new Promise((resolve) => setTimeout(resolve, 35));
+  const invalidCharacterReceived = guestSocket.next(
+    (message) => message.type === "state" && message.state?.motionSequence === 13,
+    "invalid character is sanitized",
+  );
+  hostSocket.send({
+    type: "state",
+    state: { ...hostState, motionSequence: 13, characterId: "not-a-character" },
+  });
+  const sanitizedState = (await invalidCharacterReceived).state;
+  assert.equal("characterId" in sanitizedState, false);
+
+  await new Promise((resolve) => setTimeout(resolve, 35));
+  const reconnectState = {
+    ...hostState,
+    motion: "run",
+    motionSequence: 14,
+    clientTime: 999,
+    characterId: "mio",
+  };
+  const guestReceivesReconnectState = guestSocket.next(
+    (message) => message.type === "state" && message.state?.motionSequence === 14,
+    "guest receives reconnect baseline",
+  );
+  hostSocket.send({ type: "state", state: reconnectState });
+  assert.deepEqual((await guestReceivesReconnectState).state, reconnectState);
+
+  const bubbleReceived = hostSocket.next(
+    (message) => message.type === "bubble" && message.sequence === 7,
+    "bubble relay",
+  );
+  guestSocket.send({ type: "bubble", text: "  ぐるぐる〜\u0000  ", sequence: 7 });
+  const bubble = await bubbleReceived;
+  assert.equal(bubble.role, "guest");
+  assert.equal(bubble.text, "ぐるぐる〜");
+
+  const pongReceived = hostSocket.next((message) => message.type === "pong", "heartbeat pong");
+  hostSocket.send({ type: "ping", clientTime: 789 });
+  const pong = await pongReceived;
+  assert.equal(typeof pong.serverTime, "number");
+
+  const hostSeesDisconnect = hostSocket.next(
+    (message) => message.type === "presence" && message.presence?.guest === false,
+    "host sees guest disconnect",
+  );
+  await guestSocket.close();
+  guestSocket = undefined;
+  await hostSeesDisconnect;
+
+  const hostSeesResume = hostSocket.next(
+    (message) => message.type === "presence" && message.presence?.guest === true,
+    "host sees guest resume",
+  );
+  resumedGuestSocket = await SocketProbe.connect(guest, "resumed guest");
+  const resumedWelcome = await resumedGuestSocket.next(
+    (message) => message.type === "welcome",
+    "resumed guest welcome",
+  );
+  assert.equal(resumedWelcome.role, "guest");
+  assert.equal(resumedWelcome.peerState?.characterId, "mio");
+  assert.equal(resumedWelcome.peerState?.motionSequence, 14);
+  await hostSeesResume;
+
+  const summary = {
+    ok: true,
+    baseUrl: baseUrl.origin,
+    roomCode: host.roomCode,
+    release: release
+      ? { version: release.version, gitSha: release.gitSha, builtAt: release.builtAt }
+      : null,
+    checks: [
+      "static-app",
+      "create-and-join",
+      "capacity-limit",
+      "presence",
+      "bidirectional-state",
+      "character-sync",
+      "character-allow-list",
+      "bubble-sanitization",
+      "ping-pong",
+      "guest-reconnect",
+    ],
+    durationMs: Date.now() - startedAt,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+try {
+  await run();
+} finally {
+  await Promise.allSettled([
+    hostSocket?.close(),
+    guestSocket?.close(),
+    resumedGuestSocket?.close(),
+  ]);
+}

--- a/scripts/write-release-meta.mjs
+++ b/scripts/write-release-meta.mjs
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const packageJson = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+
+function readGitSha() {
+  const candidates = [
+    process.env.AORI_BUILD_SHA,
+    process.env.GITHUB_SHA,
+    process.env.CF_PAGES_COMMIT_SHA,
+    process.env.CI_COMMIT_SHA,
+    process.env.COMMIT_SHA,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && /^[0-9a-f]{7,40}$/i.test(candidate.trim())) {
+      return candidate.trim().toLowerCase();
+    }
+  }
+
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim().toLowerCase();
+  } catch {
+    return "unknown";
+  }
+}
+
+const release = {
+  service: "aori-room",
+  version: String(packageJson.version ?? "0.0.0"),
+  protocolVersion: 2,
+  gitSha: readGitSha(),
+  builtAt: new Date().toISOString(),
+  characters: ["lumi", "mio", "sena"],
+};
+
+const publicDirectory = resolve(root, "public");
+mkdirSync(publicDirectory, { recursive: true });
+writeFileSync(resolve(publicDirectory, "release.json"), `${JSON.stringify(release, null, 2)}\n`);
+console.log(`release metadata: ${release.gitSha} (${release.version})`);


### PR DESCRIPTION
## 変更内容

- ビルド時に `release.json` を生成し、公開中のGit SHAを照合できるようにする
- ローカルWorkerに対するHTTP/WebSocketスモークテストを拡張する
- 2人上限、双方向状態、3キャラ同期、不正ID除去、吹き出しサニタイズ、ping/pong、切断・再接続を検証する
- PRごとのユニットテスト・型検査・本番ビルド・Durable Object実通信を必須ゲート化する
- デプロイ後に同一SHAを確認してから本番スモークテストを実行する
- WebKit/iPhone 13相当でタイトル画面の描画を待ち、スクリーンショットを成果物として保存する

## 理由

ビルド成功と本番動作を分離し、古いデプロイ先を検査して誤って成功扱いすることを防ぐためです。

## 検証

- `network-smoke.mjs` と `write-release-meta.mjs` のNode構文検査
- YAML構文検査
- モックHTTP/WebSocketサーバーに対する全スモーク項目の成功
- 想定SHA不一致時に非0終了することを確認

## マージ後に一度だけ必要な設定

Actions Repository Variable `PRODUCTION_BASE_URL` に本番HTTPS URLを設定します。未設定時は本番検証を明示的に失敗させます。