### PR TITLE
Add scheduled production monitoring

### DIFF
--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -1,17 +1,22 @@
 name: AORI ROOM scheduled production monitor
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/production-monitor.yml
   schedule:
     - cron: "23 */6 * * *"
   workflow_dispatch:
     inputs:
       base_url:
-        description: Full HTTPS production URL (overrides the repository variable)
+        description: Optional HTTPS production URL override
         required: false
         type: string
 
 permissions:
   contents: read
+  deployments: read
 
 concurrency:
   group: aori-production-monitor
@@ -19,10 +24,9 @@ concurrency:
 
 jobs:
   smoke:
-    name: Scheduled API and WebSocket smoke
-    if: vars.PRODUCTION_BASE_URL != '' || (github.event_name == 'workflow_dispatch' && inputs.base_url != '')
+    name: Discover and exercise current production
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Check out deployable source
         uses: actions/checkout@v4
@@ -39,9 +43,21 @@ jobs:
         shell: bash
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Discover production URL
+        id: production
+        env:
+          OVERRIDE_URL: ${{ inputs.base_url }}
+          PRODUCTION_BASE_URL: ${{ vars.PRODUCTION_BASE_URL }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SOURCE_REF: source-direct-v1.2
+          WAIT_FOR_DISCOVERY_MS: 120000
+          DISCOVERY_POLL_MS: 10000
+        run: node scripts/resolve-production-url.mjs
+
       - name: Exercise current production
         env:
-          BASE_URL: ${{ inputs.base_url || vars.PRODUCTION_BASE_URL }}
+          BASE_URL: ${{ steps.production.outputs.url }}
           EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
           WAIT_FOR_RELEASE_MS: 0
         run: node scripts/network-smoke.mjs
@@ -49,25 +65,15 @@ jobs:
       - name: Record success summary
         shell: bash
         env:
-          BASE_URL: ${{ inputs.base_url || vars.PRODUCTION_BASE_URL }}
+          BASE_URL: ${{ steps.production.outputs.url }}
+          DISCOVERY_SOURCE: ${{ steps.production.outputs.source }}
           EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
         run: |
           {
             echo "## AORI ROOM production check"
             echo ""
             echo "- URL: $BASE_URL"
+            echo "- Discovered from: $DISCOVERY_SOURCE"
             echo "- Expected source: \`$EXPECTED_SHA\`"
             echo "- API, WebSocket, character sync, reconnect: passed"
           } >> "$GITHUB_STEP_SUMMARY"
-
-  configuration-required:
-    name: Production URL configuration
-    if: vars.PRODUCTION_BASE_URL == '' && !(github.event_name == 'workflow_dispatch' && inputs.base_url != '')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fail until the repository variable is configured
-        shell: bash
-        run: |
-          echo "PRODUCTION_BASE_URL is not configured. Add it under Settings → Secrets and variables → Actions → Variables." \
-            | tee -a "$GITHUB_STEP_SUMMARY"
-          exit 1

--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   deployments: read
 
 concurrency:
@@ -77,3 +77,56 @@ jobs:
             echo "- Expected source: \`$EXPECTED_SHA\`"
             echo "- API, WebSocket, character sync, reconnect: passed"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check out monitor status branch
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: status-repo
+          fetch-depth: 0
+
+      - name: Publish monitor status
+        if: always()
+        shell: bash
+        env:
+          MONITOR_STATUS: ${{ job.status }}
+          BASE_URL: ${{ steps.production.outputs.url }}
+          DISCOVERY_SOURCE: ${{ steps.production.outputs.source }}
+          EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cd status-repo
+          mkdir -p release/production-monitor
+          node --input-type=module <<'NODE'
+          import { writeFileSync } from "node:fs";
+          const result = {
+            status: process.env.MONITOR_STATUS,
+            productionUrl: process.env.BASE_URL || null,
+            discoverySource: process.env.DISCOVERY_SOURCE || null,
+            expectedSourceSha: process.env.EXPECTED_SHA || null,
+            workflowRunId: process.env.RUN_ID,
+            workflowRunUrl: `https://github.com/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID}`,
+            recordedAt: new Date().toISOString(),
+          };
+          writeFileSync(
+            "release/production-monitor/status.json",
+            `${JSON.stringify(result, null, 2)}\n`,
+          );
+          NODE
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add release/production-monitor/status.json
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Record production monitor status: $MONITOR_STATUS [skip ci]"
+          for attempt in 1 2; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            git pull --rebase origin main
+          done
+          exit 1

--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -1,0 +1,73 @@
+name: AORI ROOM scheduled production monitor
+
+on:
+  schedule:
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Full HTTPS production URL (overrides the repository variable)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aori-production-monitor
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Scheduled API and WebSocket smoke
+    if: vars.PRODUCTION_BASE_URL != '' || (github.event_name == 'workflow_dispatch' && inputs.base_url != '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out deployable source
+        uses: actions/checkout@v4
+        with:
+          ref: source-direct-v1.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Resolve source revision
+        id: revision
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Exercise current production
+        env:
+          BASE_URL: ${{ inputs.base_url || vars.PRODUCTION_BASE_URL }}
+          EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
+          WAIT_FOR_RELEASE_MS: 0
+        run: node scripts/network-smoke.mjs
+
+      - name: Record success summary
+        shell: bash
+        env:
+          BASE_URL: ${{ inputs.base_url || vars.PRODUCTION_BASE_URL }}
+          EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
+        run: |
+          {
+            echo "## AORI ROOM production check"
+            echo ""
+            echo "- URL: $BASE_URL"
+            echo "- Expected source: \`$EXPECTED_SHA\`"
+            echo "- API, WebSocket, character sync, reconnect: passed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  configuration-required:
+    name: Production URL configuration
+    if: vars.PRODUCTION_BASE_URL == '' && !(github.event_name == 'workflow_dispatch' && inputs.base_url != '')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail until the repository variable is configured
+        shell: bash
+        run: |
+          echo "PRODUCTION_BASE_URL is not configured. Add it under Settings → Secrets and variables → Actions → Variables." \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 1


### PR DESCRIPTION
## 変更内容

- デフォルトブランチ上に6時間ごとの本番監視ワークフローを追加
- `source-direct-v1.2`の最新SHAと本番`release.json`を照合
- GitHub Deployments、Repository Homepage、Cloudflare既定ホスト名から本番URLを自動発見
- 一致した本番に対してAPI、WebSocket、キャラクター同期、再接続のスモークテストを実行
- 手動実行時だけ一時的な本番URLで上書き可能
- 監視ワークフローのマージ時にも一度実行し、設定直後の状態を確認

## 依存関係

このPRは、`source-direct-v1.2`向けPR #4で追加する`resolve-production-url.mjs`、`release.json`、`network-smoke.mjs`を利用します。#4 のマージと本番検証後に有効化します。

## 失敗時の扱い

公開先を発見できない、デプロイSHAが一致しない、API／WebSocket／キャラクター同期／再接続のいずれかが壊れた場合は、監視を緑にせず明示的に失敗させます。