### PR TITLE
Promote beautiful 3D v3 source to the production branch

### DIFF
--- a/.github/workflows/promote-source-to-main.yml
+++ b/.github/workflows/promote-source-to-main.yml
@@ -1,0 +1,91 @@
+name: Promote verified AORI ROOM source to main
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/promote-source-to-main.yml
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Verified source branch or commit
+        required: false
+        default: source-direct-v1.2
+        type: string
+  workflow_run:
+    workflows: ["AORI ROOM quality gates"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: aori-promote-source-to-main
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Materialize deployable source on main
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'source-direct-v1.2')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out main control branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+          fetch-depth: 0
+
+      - name: Check out verified deployable source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.source_ref || 'source-direct-v1.2' }}
+          path: source
+          fetch-depth: 1
+
+      - name: Confirm the source release is beautiful 3D v3
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(node -p "require('./source/package.json').version")" = "3.0.0"
+          grep -q 'beautiful-3d-v3' source/src/game/beautifulAvatar.ts
+          grep -q 'title-preview--ready' source/src/titlePreview.ts
+          node source/scripts/visual-contract.mjs
+
+      - name: Replace the legacy wrapper with the verified source tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          rsync -a --delete \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='release/' \
+            source/ main/
+          rm -rf main/app main/.wrangler
+
+      - name: Commit deployable main tree
+        working-directory: main
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.source_ref || 'source-direct-v1.2' }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "main already contains the verified source"
+            exit 0
+          fi
+          git commit -m "Promote beautiful 3D v3 production source"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            git pull --rebase origin main
+          done
+          exit 1


### PR DESCRIPTION
## 目的

検証済みの `source-direct-v1.2` を、Cloudflareの既存Git連携が監視しているデフォルトブランチ `main` へ安全に同期します。

## 動作

- 品質ゲート成功済みのsource SHAだけを対象にする
- v3.0.0、`beautiful-3d-v3`、ライブ3Dタイトル契約を同期前に検証
- `.github` と `release` の運用履歴を保持しながら、旧ZIP／パッチャー型ラッパーを直接ソースへ置換
- 初回マージ時に自動実行し、以後もsource品質ゲート成功後に自動昇格
- mainへのpushにより既存Cloudflare Gitビルドを起動可能にする

## 安全性

GitHub Actions上でのみ同期し、検証に失敗した場合はmainへ書き込みません。外部認証情報をリポジトリへ保存しません。