### PR TITLE
Verify the live beautiful 3D v3 production release

### DIFF
--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
     paths:
+      - package.json
+      - src/**
+      - worker/**
+      - public/**
+      - wrangler.jsonc
       - .github/workflows/production-monitor.yml
   schedule:
     - cron: "23 */6 * * *"
@@ -24,24 +29,32 @@ concurrency:
 
 jobs:
   smoke:
-    name: Discover and exercise current production
+    name: Discover and exercise current beautiful 3D production
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
-      - name: Check out deployable source
+      - name: Check out production source
         uses: actions/checkout@v4
         with:
-          ref: source-direct-v1.2
+          ref: main
+          fetch-depth: 1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Resolve source revision
+      - name: Resolve production revision
         id: revision
         shell: bash
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Confirm local beautiful 3D contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(node -p "require('./package.json').version")" = "3.0.0"
+          node scripts/visual-contract.mjs
 
       - name: Discover production URL
         id: production
@@ -50,17 +63,59 @@ jobs:
           PRODUCTION_BASE_URL: ${{ vars.PRODUCTION_BASE_URL }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          SOURCE_REF: source-direct-v1.2
-          WAIT_FOR_DISCOVERY_MS: 120000
+          SOURCE_REF: main
+          WAIT_FOR_DISCOVERY_MS: 300000
           DISCOVERY_POLL_MS: 10000
         run: node scripts/resolve-production-url.mjs
 
-      - name: Exercise current production
+      - name: Wait for this revision and exercise production
         env:
           BASE_URL: ${{ steps.production.outputs.url }}
           EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
-          WAIT_FOR_RELEASE_MS: 0
+          WAIT_FOR_RELEASE_MS: 900000
+          RELEASE_POLL_MS: 5000
         run: node scripts/network-smoke.mjs
+
+      - name: Verify beautiful 3D release metadata
+        shell: bash
+        env:
+          BASE_URL: ${{ steps.production.outputs.url }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const base = process.env.BASE_URL.replace(/\/$/, "");
+          const response = await fetch(`${base}/release.json`, {
+            headers: { "cache-control": "no-cache" },
+          });
+          if (!response.ok) throw new Error(`release.json returned ${response.status}`);
+          const release = await response.json();
+          if (release.service !== "aori-room") throw new Error("unexpected service");
+          if (release.version !== "3.0.0") throw new Error(`unexpected version ${release.version}`);
+          if (release.visualVersion !== "beautiful-3d-v3") {
+            throw new Error(`unexpected visual version ${release.visualVersion}`);
+          }
+          if (release.capabilities?.liveTitle3D !== true) throw new Error("live title 3D is not declared");
+          if (release.capabilities?.beautifulAvatarRig !== true) throw new Error("beautiful avatar rig is not declared");
+          console.log(JSON.stringify(release, null, 2));
+          NODE
+
+      - name: Capture verified beautiful 3D title on iPhone WebKit
+        id: screenshot
+        shell: bash
+        env:
+          BASE_URL: ${{ steps.production.outputs.url }}
+        run: |
+          set -euo pipefail
+          mkdir -p production-artifacts
+          npx --yes playwright@latest install --with-deps webkit
+          npx --yes playwright@latest screenshot \
+            --browser=webkit \
+            --device="iPhone 13" \
+            --wait-for-selector=".title-preview--ready" \
+            --wait-for-timeout=3500 \
+            "$BASE_URL" \
+            production-artifacts/title-iphone.png
+          test -s production-artifacts/title-iphone.png
 
       - name: Record success summary
         shell: bash
@@ -70,13 +125,24 @@ jobs:
           EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
         run: |
           {
-            echo "## AORI ROOM production check"
+            echo "## AORI ROOM beautiful 3D production check"
             echo ""
             echo "- URL: $BASE_URL"
             echo "- Discovered from: $DISCOVERY_SOURCE"
-            echo "- Expected source: \`$EXPECTED_SHA\`"
-            echo "- API, WebSocket, character sync, reconnect: passed"
+            echo "- Verified main revision: \`$EXPECTED_SHA\`"
+            echo "- v3.0.0 / beautiful-3d-v3 metadata: passed"
+            echo "- API, Durable Object, WebSocket, character sync, reconnect: passed"
+            echo "- iPhone WebKit live 3D title render: passed"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload production evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: beautiful-3d-production-${{ steps.revision.outputs.sha || github.run_id }}
+          path: production-artifacts/
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: Check out monitor status branch
         if: always()
@@ -94,6 +160,7 @@ jobs:
           BASE_URL: ${{ steps.production.outputs.url }}
           DISCOVERY_SOURCE: ${{ steps.production.outputs.source }}
           EXPECTED_SHA: ${{ steps.revision.outputs.sha }}
+          SCREENSHOT_OUTCOME: ${{ steps.screenshot.outcome }}
           RUN_ID: ${{ github.run_id }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -106,7 +173,10 @@ jobs:
             status: process.env.MONITOR_STATUS,
             productionUrl: process.env.BASE_URL || null,
             discoverySource: process.env.DISCOVERY_SOURCE || null,
-            expectedSourceSha: process.env.EXPECTED_SHA || null,
+            expectedMainSha: process.env.EXPECTED_SHA || null,
+            version: "3.0.0",
+            visualVersion: "beautiful-3d-v3",
+            screenshotOutcome: process.env.SCREENSHOT_OUTCOME || null,
             workflowRunId: process.env.RUN_ID,
             workflowRunUrl: `https://github.com/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID}`,
             recordedAt: new Date().toISOString(),
@@ -122,8 +192,8 @@ jobs:
           if git diff --cached --quiet; then
             exit 0
           fi
-          git commit -m "Record production monitor status: $MONITOR_STATUS [skip ci]"
-          for attempt in 1 2; do
+          git commit -m "Record beautiful 3D production monitor status: $MONITOR_STATUS [skip ci]"
+          for attempt in 1 2 3; do
             if git push origin HEAD:main; then
               exit 0
             fi


### PR DESCRIPTION
## 目的

本番に公開されたmainリビジョンを自動発見し、v3.0.0の美麗3D版が実際に動作していることまで検証します。

## 検証内容

- 公開URLの自動発見
- mainの正確なGit SHAと`release.json`の一致
- `version=3.0.0`、`visualVersion=beautiful-3d-v3`
- API、Durable Object、WebSocket、2人入室、キャラクター同期、再接続
- iPhone 13相当WebKitで`.title-preview--ready`を待機しスクリーンショット取得
- URL、SHA、描画結果を`release/production-monitor/status.json`へ保存

mainのソース／Worker／設定変更でも監視を起動し、古い公開版を成功扱いしません。