### PR TITLE
Discover Cloudflare production from commit checks

### DIFF
--- a/.github/inspect-production-signals-trigger
+++ b/.github/inspect-production-signals-trigger
@@ -1,0 +1,1 @@
+inspect GitHub deployment signals for promoted main commit 869bb98c0fbf1418a4330610801ad1f49e5a4c91

--- a/.github/inspect-production-signals-trigger
+++ b/.github/inspect-production-signals-trigger
@@ -1,1 +1,1 @@
-inspect GitHub deployment signals for promoted main commit 869bb98c0fbf1418a4330610801ad1f49e5a4c91
+inspect GitHub deployment signals and annotations for promoted main commit 869bb98c0fbf1418a4330610801ad1f49e5a4c91

--- a/.github/probe-cloudflare-public-metadata-trigger
+++ b/.github/probe-cloudflare-public-metadata-trigger
@@ -1,0 +1,1 @@
+probe unauthenticated Cloudflare metadata for account d068687e2a79aee7f87e031a93b6d54b

--- a/.github/verify-promoted-main-trigger
+++ b/.github/verify-promoted-main-trigger
@@ -1,0 +1,1 @@
+verify promoted main commit 869bb98c0fbf1418a4330610801ad1f49e5a4c91 with resolver v2

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
   deployments: read
+  checks: read
+  statuses: read
+  pages: read
 
 concurrency:
   group: aori-quality-${{ github.workflow }}-${{ github.ref }}
@@ -124,6 +127,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SOURCE_REF: source-direct-v1.2
+          SOURCE_SHA: ${{ github.sha }}
           WAIT_FOR_DISCOVERY_MS: 300000
           DISCOVERY_POLL_MS: 10000
         run: node scripts/resolve-production-url.mjs

--- a/scripts/resolve-production-url-selftest.mjs
+++ b/scripts/resolve-production-url-selftest.mjs
@@ -12,19 +12,30 @@ test("accepts only normalized public HTTPS production candidates", () => {
     url: "https://example.com/app",
     source: "test",
   });
+  assert.deepEqual(
+    normalizeCandidate("https://gpt-de-asobu.example.workers.dev/).", "check output"),
+    {
+      url: "https://gpt-de-asobu.example.workers.dev",
+      source: "check output",
+    },
+  );
   assert.equal(normalizeCandidate("http://example.com", "test"), null);
   assert.equal(normalizeCandidate("https://127.0.0.1", "test"), null);
   assert.equal(normalizeCandidate("https://192.168.1.4", "test"), null);
   assert.equal(normalizeCandidate("https://github.com/Milluna/GPT-DE-ASOBU", "test"), null);
+  assert.equal(normalizeCandidate("https://dash.cloudflare.com/example", "test"), null);
   assert.equal(isPublicHostname("gpt-de-asobu.milluna.workers.dev"), true);
 });
 
-test("extracts nested HTTPS deployment URLs", () => {
+test("extracts nested HTTPS deployment and check-output URLs", () => {
   const urls = [];
   collectUrls(
     {
       payload: {
         message: "deployed to https://gpt-de-asobu.example.workers.dev and https://example.com/app",
+      },
+      output: {
+        summary: "[Open deployment](https://preview.example.workers.dev/)",
       },
     },
     urls,
@@ -32,6 +43,7 @@ test("extracts nested HTTPS deployment URLs", () => {
   assert.deepEqual(urls, [
     "https://gpt-de-asobu.example.workers.dev",
     "https://example.com/app",
+    "https://preview.example.workers.dev/)",
   ]);
 });
 

--- a/scripts/resolve-production-url.mjs
+++ b/scripts/resolve-production-url.mjs
@@ -5,10 +5,11 @@ import { pathToFileURL } from "node:url";
 const SERVICE_NAME = "gpt-de-asobu";
 const APP_SERVICE = "aori-room";
 const SOURCE_REF = process.env.SOURCE_REF || "source-direct-v1.2";
+const SOURCE_SHA = process.env.SOURCE_SHA || process.env.EXPECTED_SHA || "";
 const WAIT_MS = readDuration("WAIT_FOR_DISCOVERY_MS", 0);
 const POLL_MS = Math.max(1_000, readDuration("DISCOVERY_POLL_MS", 15_000));
 const PROBE_TIMEOUT_MS = Math.max(1_000, readDuration("PROBE_TIMEOUT_MS", 10_000));
-const USER_AGENT = "aori-room-production-resolver/1";
+const USER_AGENT = "aori-room-production-resolver/2";
 
 function readDuration(name, fallback) {
   const value = Number(process.env[name] ?? fallback);
@@ -16,13 +17,14 @@ function readDuration(name, fallback) {
 }
 
 function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
 
 function normalizeCandidate(raw, source) {
   if (typeof raw !== "string" || raw.trim() === "") return null;
   try {
-    const url = new URL(raw.trim());
+    const clean = raw.trim().replace(/[\])},.;:]+$/g, "");
+    const url = new URL(clean);
     if (url.protocol !== "https:") return null;
     if (url.username || url.password || !isPublicHostname(url.hostname)) return null;
     url.hash = "";
@@ -37,7 +39,13 @@ function normalizeCandidate(raw, source) {
 function isPublicHostname(hostname) {
   const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) return false;
-  if (["github.com", "api.github.com", "cloudflare.com", "dash.cloudflare.com"].includes(host)) return false;
+  if (
+    host === "github.com" ||
+    host.endsWith(".github.com") ||
+    host === "api.github.com" ||
+    host === "cloudflare.com" ||
+    host.endsWith(".cloudflare.com")
+  ) return false;
   if (host === "::1" || host === "0.0.0.0" || host.startsWith("127.")) return false;
   if (host.startsWith("10.") || host.startsWith("192.168.") || host.startsWith("169.254.")) return false;
   const match = host.match(/^172\.(\d{1,3})\./);
@@ -53,7 +61,7 @@ function addCandidate(list, seen, raw, source) {
 }
 
 function collectUrls(value, output, depth = 0) {
-  if (depth > 4 || value == null) return;
+  if (depth > 6 || value == null) return;
   if (typeof value === "string") {
     for (const match of value.matchAll(/https:\/\/[^\s"'<>]+/g)) output.push(match[0]);
     return;
@@ -86,7 +94,7 @@ async function fetchWithTimeout(url, init = {}) {
   }
 }
 
-async function githubJson(path) {
+async function githubJson(path, { allowNotFound = false } = {}) {
   const token = process.env.GITHUB_TOKEN;
   const repository = process.env.GITHUB_REPOSITORY;
   if (!token || !repository) return null;
@@ -97,8 +105,86 @@ async function githubJson(path) {
       "x-github-api-version": "2022-11-28",
     },
   });
+  if (allowNotFound && response.status === 404) return null;
   if (!response.ok) throw new Error(`GitHub API ${response.status} for ${path}`);
   return response.json();
+}
+
+function addUrlsFromPayload(candidates, seen, payload, source) {
+  const urls = [];
+  collectUrls(payload, urls);
+  for (const url of urls) addCandidate(candidates, seen, url, source);
+}
+
+async function addDeploymentCandidates(candidates, seen, repository) {
+  const queries = new Set([`ref=${encodeURIComponent(SOURCE_REF)}`]);
+  if (SOURCE_SHA) queries.add(`sha=${encodeURIComponent(SOURCE_SHA)}`);
+  const deploymentsById = new Map();
+  for (const query of queries) {
+    const deployments = await githubJson(`/repos/${repository}/deployments?${query}&per_page=50`);
+    if (!Array.isArray(deployments)) continue;
+    for (const deployment of deployments) deploymentsById.set(deployment.id, deployment);
+  }
+
+  for (const deployment of deploymentsById.values()) {
+    const statusList = await githubJson(
+      `/repos/${repository}/deployments/${deployment.id}/statuses?per_page=50`,
+    );
+    if (Array.isArray(statusList)) {
+      for (const status of statusList) {
+        if (!["success", "in_progress", "queued", "pending"].includes(status?.state)) continue;
+        addCandidate(candidates, seen, status.environment_url, "GitHub deployment environment");
+        addCandidate(candidates, seen, status.target_url, "GitHub deployment target");
+        addUrlsFromPayload(candidates, seen, status, "GitHub deployment status");
+      }
+    }
+    addUrlsFromPayload(candidates, seen, deployment, "GitHub deployment payload");
+  }
+}
+
+async function addCommitSignalCandidates(candidates, seen, repository) {
+  const revision = SOURCE_SHA || SOURCE_REF;
+  if (!revision) return;
+  const encodedRevision = encodeURIComponent(revision);
+
+  try {
+    const statuses = await githubJson(
+      `/repos/${repository}/commits/${encodedRevision}/statuses?per_page=100`,
+    );
+    if (Array.isArray(statuses)) {
+      for (const status of statuses) {
+        addCandidate(candidates, seen, status.target_url, "GitHub commit status target");
+        addUrlsFromPayload(candidates, seen, status, "GitHub commit status");
+      }
+    }
+  } catch (error) {
+    console.warn(`commit status discovery unavailable: ${error instanceof Error ? error.message : error}`);
+  }
+
+  try {
+    const checkRuns = await githubJson(
+      `/repos/${repository}/commits/${encodedRevision}/check-runs?filter=latest&per_page=100`,
+    );
+    if (Array.isArray(checkRuns?.check_runs)) {
+      for (const check of checkRuns.check_runs) {
+        addCandidate(candidates, seen, check.details_url, "GitHub check details");
+        addUrlsFromPayload(candidates, seen, check, "GitHub check output");
+      }
+    }
+  } catch (error) {
+    console.warn(`check-run discovery unavailable: ${error instanceof Error ? error.message : error}`);
+  }
+
+  try {
+    const comments = await githubJson(
+      `/repos/${repository}/commits/${encodedRevision}/comments?per_page=100`,
+    );
+    if (Array.isArray(comments)) {
+      for (const comment of comments) addUrlsFromPayload(candidates, seen, comment, "GitHub commit comment");
+    }
+  } catch (error) {
+    console.warn(`commit comment discovery unavailable: ${error instanceof Error ? error.message : error}`);
+  }
 }
 
 async function discoverCandidates() {
@@ -110,32 +196,12 @@ async function discoverCandidates() {
   const repository = process.env.GITHUB_REPOSITORY;
   if (repository) {
     try {
-      const deployments = await githubJson(
-        `/repos/${repository}/deployments?ref=${encodeURIComponent(SOURCE_REF)}&per_page=20`,
-      );
-      if (Array.isArray(deployments)) {
-        for (const deployment of deployments) {
-          const statusList = await githubJson(
-            `/repos/${repository}/deployments/${deployment.id}/statuses?per_page=20`,
-          );
-          if (Array.isArray(statusList)) {
-            for (const status of statusList) {
-              if (status?.state !== "success" && status?.state !== "in_progress") continue;
-              addCandidate(candidates, seen, status.environment_url, "GitHub deployment environment");
-              addCandidate(candidates, seen, status.target_url, "GitHub deployment target");
-              const urls = [];
-              collectUrls(status, urls);
-              for (const url of urls) addCandidate(candidates, seen, url, "GitHub deployment status");
-            }
-          }
-          const urls = [];
-          collectUrls(deployment, urls);
-          for (const url of urls) addCandidate(candidates, seen, url, "GitHub deployment payload");
-        }
-      }
+      await addDeploymentCandidates(candidates, seen, repository);
     } catch (error) {
       console.warn(`deployment discovery unavailable: ${error instanceof Error ? error.message : error}`);
     }
+
+    await addCommitSignalCandidates(candidates, seen, repository);
 
     try {
       const repositoryData = await githubJson(`/repos/${repository}`);
@@ -144,16 +210,39 @@ async function discoverCandidates() {
       console.warn(`repository homepage discovery unavailable: ${error instanceof Error ? error.message : error}`);
     }
 
-    const [owner] = repository.split("/");
+    try {
+      const pages = await githubJson(`/repos/${repository}/pages`, { allowNotFound: true });
+      addCandidate(candidates, seen, pages?.html_url, "GitHub Pages configuration");
+    } catch (error) {
+      console.warn(`GitHub Pages discovery unavailable: ${error instanceof Error ? error.message : error}`);
+    }
+
+    const [owner, repositoryName] = repository.split("/");
     if (owner) {
+      const ownerSlug = owner.toLowerCase();
       addCandidate(
         candidates,
         seen,
-        `https://${SERVICE_NAME}.${owner.toLowerCase()}.workers.dev`,
+        `https://${SERVICE_NAME}.${ownerSlug}.workers.dev`,
         "Cloudflare conventional hostname",
       );
+      addCandidate(
+        candidates,
+        seen,
+        `https://${SERVICE_NAME}-${ownerSlug}.pages.dev`,
+        "Cloudflare owner-qualified Pages hostname",
+      );
+      if (repositoryName) {
+        addCandidate(
+          candidates,
+          seen,
+          `https://${ownerSlug}.github.io/${repositoryName}`,
+          "GitHub Pages conventional hostname",
+        );
+      }
     }
   }
+  addCandidate(candidates, seen, `https://${SERVICE_NAME}.workers.dev`, "Legacy Workers hostname");
   addCandidate(candidates, seen, `https://${SERVICE_NAME}.pages.dev`, "Cloudflare Pages hostname");
   return candidates;
 }
@@ -224,11 +313,17 @@ async function main() {
   } while (Date.now() <= deadline);
 
   throw new Error(
-    "Could not discover a verified AORI ROOM production URL from workflow input, repository variable, GitHub deployments, repository homepage, or conventional Cloudflare hostnames.",
+    "Could not discover a verified AORI ROOM production URL from workflow input, repository variables, GitHub deployments, commit statuses, check output, commit comments, repository metadata, or conventional hosting names.",
   );
 }
 
 const entryPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
 if (entryPath === import.meta.url) await main();
 
-export { collectUrls, isPublicHostname, normalizeCandidate, verifyCandidate };
+export {
+  collectUrls,
+  discoverCandidates,
+  isPublicHostname,
+  normalizeCandidate,
+  verifyCandidate,
+};


### PR DESCRIPTION
## 変更内容

- GitHub Deploymentsに加え、commit statuses、check runs、commit comments、GitHub Pages設定から公開URL候補を抽出
- Cloudflareのチェック出力に含まれるMarkdown URL末尾記号を正規化
- dashboard、GitHub、private networkを引き続き候補から除外
- refだけでなく正確なcommit SHAでもdeployment／check情報を照合
- Workers／Pages／GitHub Pagesの追加ホスト候補を検証
- resolver自己テストとActions権限を更新

## 目的

Cloudflare Git連携がGitHub Deploymentを作らず、check runだけへ公開先を記録する構成でも、本番URLを人手なしで発見して同一SHA検証へ進めるためです。