### PR TITLE
Keep Vitest focused on unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpt-de-asobu",
   "version": "3.0.0",
   "scripts": {
-    "test": "vitest run && node scripts/visual-contract.mjs",
+    "test": "vitest run tests && node scripts/visual-contract.mjs",
     "dev": "vite --host 0.0.0.0",
     "dev:worker": "wrangler dev --local --port 8787",
     "dev:full": "npm run build && npm run dev:worker",


### PR DESCRIPTION
`scripts/static-live.spec.mjs` is a Playwright production test, not a Vitest suite. Limit `bun run test` to the `tests` directory so the unit/visual contract gate remains deterministic while Playwright checks continue in their dedicated workflows.